### PR TITLE
Use current dir as base when checking excludes

### DIFF
--- a/util/files.go
+++ b/util/files.go
@@ -27,7 +27,7 @@ import (
 // IsPathExcluded determines if the provided path is excluded from common searches
 func IsPathExcluded(paths []string, path string) bool {
 	for _, exclude := range paths {
-		if strings.Contains(path, "/"+exclude) {
+		if strings.HasPrefix(path, exclude) {
 			return true
 		}
 	}
@@ -83,7 +83,7 @@ func GoLintExcludes() []string {
 func GetProjectFileDirectories(paths []string) ([]string, error) {
 	directories := make([]string, 0)
 
-	err := filepath.Walk("../", func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk("./", func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() && !IsPathExcluded(paths, path) {
 			directories = append(directories, path)
 		}


### PR DESCRIPTION
**Before: **

```
/Users/tadas/go/bin/goimports -e -l ../ ../devbook ../devbook/assets ../devbook/assets/css ../devbook/assets/img ../devbook/assets/img/ci ../devbook/ci ../devbook/code-review ../devbook/git ../feedback ../feedback/client ../feedback/cmd ../feedback/feedback ../feedback/infra ../feedback/infra/apierror ../feedback/server ../location-oracle ../location-oracle/cmd ../location-oracle/handler ../location-oracle/locpro ../location-oracle/locpro/cache ../location-oracle/locpro/cache/storage ../location-oracle/locpro/maxmind ../location-oracle/model
```

**After: **
```
/Users/tadas/go/bin/goimports -e -l ./ cmd handler locpro locpro/cache locpro/cache/storage locpro/maxmind model
```